### PR TITLE
Update dbus-home-wizzard-energy-p1.py

### DIFF
--- a/dbus-home-wizzard-energy-p1.py
+++ b/dbus-home-wizzard-energy-p1.py
@@ -180,8 +180,8 @@ class DbusHomeWizzardEnergyP1Service:
                 # self._dbusservice['/Ac/L3/Power'] = meter_data['active_power_l1_w']
                 self._dbusservice['/Ac/Energy/Forward'] = (meter_data['total_power_import_kwh']/1000)
                 self._dbusservice['/Ac/Energy/Reverse'] = (meter_data['total_power_export_kwh']/1000)
-                self._dbusservice['/Ac/L1/Energy/Forward'] = (meter_data['total_power_import_kwh']/1000)
-                self._dbusservice['/Ac/L1/Energy/Reverse'] = (meter_data['total_power_export_kwh']/1000) 
+                #self._dbusservice['/Ac/L1/Energy/Forward'] = (meter_data['total_power_import_kwh']/1000)
+                #self._dbusservice['/Ac/L1/Energy/Reverse'] = (meter_data['total_power_export_kwh']/1000) 
             if phases == '3':
                 #send data to DBus for 3pahse system
                 self._dbusservice['/Ac/Power'] = meter_data['active_power_w']


### PR DESCRIPTION
fix log filling with
2025-07-27 14:10:49,29 root CRITICAL Error at _update Traceback (most recent call last):
  File "/data/dbus-Home-Wizzard-Energy-P1/dbus-home-wizzard-energy-p1.py", line 184, in _update
    self._dbusservice['/Ac/L1/Energy/Reverse'] = (meter_data['total_power_export_kwh'])
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/victronenergy/dbus-systemcalc-py/ext/velib_python/vedbus.py", line 172, in __setitem__
    self._dbusobjects[path].local_set_value(newvalue)
    ~~~~~~~~~~~~~~~~~^^^^^^
KeyError: '/Ac/L1/Energy/Reverse'